### PR TITLE
web.md: Add missing linebreak

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -25,6 +25,7 @@
 [The Learn Go Programming blog on Medium](https://blog.learngoprogramming.com) starting with [Why Go?](https://blog.learngoprogramming.com/about-go-language-an-overview-f0bee143597c)
 
 [Go by Example](https://gobyexample.com/)
+
 [Why Go?](https://dave.cheney.net/2017/03/20/why-go)
 
 [Why Go? — Key advantages you may have overlooked](https://yourbasic.org/golang/advantages-over-java-python)


### PR DESCRIPTION
Add a blank line between articles "Go by Example" and "Why Go?" so that the generated Links are displayed on separate lines.